### PR TITLE
add log for server start failed with signature not identical, and uni…

### DIFF
--- a/lib/uiautomator-client.js
+++ b/lib/uiautomator-client.js
@@ -19,6 +19,8 @@ UIAutomator.prototype.init = function *(adb) {
   this.initProxy();
   yield this.adb.forward(this.proxyPort, this.proxyPort);
   const ANDROID_TMP_DIR = this.adb.getTmpDir();
+  yield this.adb.shell(`pm uninstall "${UIAUTOMATORWD.TEST_PACKAGE}"`);
+  yield this.adb.shell(`pm uninstall "${UIAUTOMATORWD.TEST_PACKAGE}.test"`);
   yield this.adb.push(UIAUTOMATORWD.TEST_APK_BUILD_PATH, `${ANDROID_TMP_DIR}/${UIAUTOMATORWD.TEST_PACKAGE}`);
   yield this.adb.shell(`pm install -r "${ANDROID_TMP_DIR}/${UIAUTOMATORWD.TEST_PACKAGE}"`);
   yield this.adb.push(UIAUTOMATORWD.APK_BUILD_PATH, `${ANDROID_TMP_DIR}/${UIAUTOMATORWD.TEST_PACKAGE}.test`);
@@ -48,6 +50,7 @@ UIAutomator.prototype.startServer = function() {
     proc.stderr.setEncoding('utf8');
     proc.stdout.setEncoding('utf8');
     proc.stdout.on('data', data => {
+      logger.info(data);
       let match = UIAUTOMATORWD.SERVER_URL_REG.exec(data);
 
       if (match) {
@@ -60,7 +63,7 @@ UIAutomator.prototype.startServer = function() {
       }
     });
     proc.stderr.on('data', data => {
-      console.log(data);
+      logger.info(data);
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uiautomatorwd",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Node.js wrapper for UIAutomator2",
   "keywords": [
     "uiautomator",


### PR DESCRIPTION
add log for server start failed with signature not identical, and uninstall before install,due to new version may have the different signature which will cause install failed.