### PR TITLE
* [android] fixed if text is null elementByName locator not working i…

### DIFF
--- a/app/src/androidTest/java/com/macaca/android/testing/server/controllers/ElementController.java
+++ b/app/src/androidTest/java/com/macaca/android/testing/server/controllers/ElementController.java
@@ -332,7 +332,7 @@ public class ElementController extends RouterNanoHTTPD.DefaultHandler {
                 selector = By.clazz(text);
                 break;
             case "NAME":
-                selector = By.text(text);
+                selector = By.desc(text) == null ? By.text(text): By.desc(text);
                 break;
             case "ID":
                 selector = By.res(text);


### PR DESCRIPTION
if text is null elementByName locator not working in Android platform