### PR TITLE
fix call parseBody twice cause  read timeout

### DIFF
--- a/app/src/androidTest/java/fi/iki/elonen/router/RouterNanoHTTPD.java
+++ b/app/src/androidTest/java/fi/iki/elonen/router/RouterNanoHTTPD.java
@@ -560,13 +560,16 @@ public class RouterNanoHTTPD extends NanoHTTPD {
 
     @Override
     public Response serve(IHTTPSession session) {
+        long bodySize = ((HTTPSession)session).getBodySize();
+        session.getInputStream().mark(HTTPSession.BUFSIZE);
+        
         // Try to find match
         Response r = router.process(session);
-
+        
         //clear remain body
         try{
-            Map<String, String> remainBody = new HashMap<>();
-            session.parseBody(remainBody);
+            session.getInputStream().reset();
+            session.getInputStream().skip(bodySize);
         }
         catch (Exception e){
             String error = "Error: " + e.getClass().getName() + " : " + e.getMessage();


### PR DESCRIPTION
some router.process call parseBody, after that we call parseBody for the second time, cause inputstream read timeout