### PR TITLE
don't call adb.getPIds every sendCommand

### DIFF
--- a/lib/uiautomator-client.js
+++ b/lib/uiautomator-client.js
@@ -110,14 +110,13 @@ UIAutomator.prototype.startServer = function() {
 UIAutomator.prototype.sendCommand = function *(url, method, body) {
   let isServerStillAlive = true;
   let ret;
-  try{
+  try {
     ret = yield this.proxy.send(url, method, body);
-    if(typeof ret === "object" && ret.hasOwnProperty("status")){
+    if (typeof ret === 'object' && ret.hasOwnProperty('status')) {
       return ret;
     }
-  }
-  catch (e) {
-    logger.warn("proxy.send except: %s", e);
+  } catch (e) {
+    logger.warn('proxy.send except: %s', e);
   }
 
   try {

--- a/lib/uiautomator-client.js
+++ b/lib/uiautomator-client.js
@@ -112,7 +112,7 @@ UIAutomator.prototype.sendCommand = function *(url, method, body) {
   let ret;
   try {
     ret = yield this.proxy.send(url, method, body);
-    if (typeof ret === 'object' && ret.hasOwnProperty('status')) {
+    if (ret && ret.hasOwnProperty('status')) {
       return ret;
     }
   } catch (e) {

--- a/lib/uiautomator-client.js
+++ b/lib/uiautomator-client.js
@@ -109,6 +109,16 @@ UIAutomator.prototype.startServer = function() {
 
 UIAutomator.prototype.sendCommand = function *(url, method, body) {
   let isServerStillAlive = true;
+  let ret;
+  try{
+    ret = yield this.proxy.send(url, method, body);
+    if(typeof ret === "object" && ret.hasOwnProperty("status")){
+      return ret;
+    }
+  }
+  catch (e) {
+    logger.warn("proxy.send except: %s", e);
+  }
 
   try {
     let pids = yield this.adb.getPIds(UIAUTOMATORWD.TEST_PACKAGE);
@@ -123,8 +133,9 @@ UIAutomator.prototype.sendCommand = function *(url, method, body) {
     logger.info('restart UIAutomatorWD server');
     // restart the WD server
     yield this.startServer();
+    ret = yield this.proxy.send(url, method, body);
   }
-  return this.proxy.send(url, method, body);
+  return ret;
 };
 
 module.exports = UIAutomator;


### PR DESCRIPTION
frequently call adb.getPIds may cause many short connections, only when  proxy.send failed or except, call adb.getPIds check TEST_PACKAGE process exists