### PR TITLE
fix NullPointerException when use drag without “steps” parameter

### DIFF
--- a/app/src/androidTest/java/com/macaca/android/testing/server/controllers/ActionController.java
+++ b/app/src/androidTest/java/com/macaca/android/testing/server/controllers/ActionController.java
@@ -230,7 +230,7 @@ public class ActionController extends RouterNanoHTTPD.DefaultHandler {
             JSONObject action = actions.getJSONObject(i);
             if (i == 0) {
                 String elementId = action.getString("element");
-                steps = action.getInteger("steps");
+                steps = action.getIntValue("steps");
                 if (steps == 0) {
                     double duration = action.getDoubleValue("duration");
                     steps = (int) Math.round(duration * 40);


### PR DESCRIPTION
when use drag(double fromX, double fromY, double toX, double toY, double duration) to drag more than two points, if there is no “steps” parameter, it will throw NullPointerException on 
```steps = action.getInteger("steps");```