### PR TITLE
Add clear accessibility cache before request

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,11 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    lintOptions {
+        abortOnError false
+    }
+
     useLibrary 'org.apache.http.legacy'
 }
 

--- a/app/src/androidTest/java/com/macaca/android/testing/UIAutomatorWDServer.java
+++ b/app/src/androidTest/java/com/macaca/android/testing/UIAutomatorWDServer.java
@@ -5,6 +5,7 @@ import com.macaca.android.testing.server.models.Methods;
 
 import java.io.IOException;
 
+import com.macaca.android.testing.server.xmlUtils.ReflectionUtils;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.router.RouterNanoHTTPD;
 
@@ -105,5 +106,16 @@ public class UIAutomatorWDServer extends RouterNanoHTTPD {
             }
         }
         return singleton;
+    }
+
+    @Override
+    public Response serve(IHTTPSession session) {
+        try {
+            System.out.println("Try to clean up the Accessibility Node cache.");
+            ReflectionUtils.clearAccessibilityCache();
+        } catch (Exception e) {
+            System.err.println("Failed to clear Accessibility Node cache.");
+        }
+        return super.serve(session);
     }
 }

--- a/app/src/androidTest/java/com/macaca/android/testing/server/xmlUtils/ReflectionUtils.java
+++ b/app/src/androidTest/java/com/macaca/android/testing/server/xmlUtils/ReflectionUtils.java
@@ -16,9 +16,7 @@
 package com.macaca.android.testing.server.xmlUtils;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.logging.Logger;
 
 public class ReflectionUtils {
 

--- a/app/src/androidTest/java/com/macaca/android/testing/server/xmlUtils/ReflectionUtils.java
+++ b/app/src/androidTest/java/com/macaca/android/testing/server/xmlUtils/ReflectionUtils.java
@@ -16,9 +16,33 @@
 package com.macaca.android.testing.server.xmlUtils;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.logging.Logger;
 
 public class ReflectionUtils {
+
+    /**
+     * Clears the in-process Accessibility cache, removing any stale references.
+     * Because the AccessibilityInteractionClient singleton stores copies of
+     * AccessibilityNodeInfo instances, calls to public APIs such as `recycle` do
+     * not guarantee cached references get updated. See the
+     * android.view.accessibility AIC and ANI source code for more information.
+     * https://github.com/appium/appium/issues/4200
+     */
+    public static boolean clearAccessibilityCache() throws Exception {
+        boolean success;
+
+        final Class c = Class.forName("android.view.accessibility.AccessibilityInteractionClient");
+        final Method getInstance = ReflectionUtils.method(c, "getInstance");
+        final Object instance = getInstance.invoke(null);
+        final Method clearCache = ReflectionUtils.method(instance.getClass(), "clearCache");
+        clearCache.invoke(instance);
+        success = true;
+
+        return success;
+    }
+
 
     public static Class getClass(final String name) throws Exception {
         return Class.forName(name);


### PR DESCRIPTION
The element/elements/source method sometimes does not return all elements, but the appium works fine, i find the similar bug in appium https://github.com/appium/appium/issues/4200 . so i add the clearAccessibilityCache method and call it before request. Maybe we can filter the request to decide which ones should call clearAccessibilityCache before.
